### PR TITLE
fix: wrong sass file ending

### DIFF
--- a/form/_all.scss
+++ b/form/_all.scss
@@ -1,8 +1,8 @@
 @charset "utf-8";
 
-@import "shared.sass";
-@import "input-textarea.sass";
-@import "checkbox-radio.sass";
-@import "select.sass";
-@import "file.sass";
-@import "tools.sass";
+@import "shared";
+@import "input-textarea";
+@import "checkbox-radio";
+@import "select";
+@import "file";
+@import "tools";


### PR DESCRIPTION
I had problems with the import due to file /form/_all.scss. After a check i saw that there was still the file ending .sass. After deleting it, everything worked fine for me.